### PR TITLE
Suppressed self addition test for whenCompleteAsync

### DIFF
--- a/src/main/java/net/tascalate/concurrent/AbstractCompletableTask.java
+++ b/src/main/java/net/tascalate/concurrent/AbstractCompletableTask.java
@@ -322,15 +322,14 @@ abstract class AbstractCompletableTask<T> extends PromiseAdapter<T> implements P
             failure -> {
                 try {
                     action.accept(null, failure);
-                    return forwardException(failure);
                 } catch (Throwable e) {
                     // CompletableFuture does not override exception here
                     // unlike as in handle[Async](BiFunction)
                     // Preserve this behavior, but let us add at least 
                     // suppressed exception
                     failure.addSuppressed(e);
-                    return forwardException(failure);
                 }
+                return forwardException(failure);
             }, 
             executor
         );

--- a/src/test/java/net/tascalate/concurrent/WhenCompleteAsyncTest.java
+++ b/src/test/java/net/tascalate/concurrent/WhenCompleteAsyncTest.java
@@ -1,0 +1,31 @@
+package net.tascalate.concurrent;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Adam Jurčík
+ */
+public class WhenCompleteAsyncTest {
+    
+    @Test
+    public void testSuppressedSelfAddition() throws InterruptedException, ExecutionException {
+        Promise<Throwable> failure = CompletableTask
+                .asyncOn(ForkJoinPool.commonPool())
+                .thenRunAsync(
+                        () -> {
+                            throw new CompletionException(new Exception());
+                        })
+                .whenCompleteAsync((r, ex) -> { /* no action */ })
+                .handleAsync((r, ex) -> ex);
+        
+        Throwable t = failure.get();
+        
+        Assert.assertThat(t, CoreMatchers.instanceOf(CompletionException.class));
+    }
+    
+}


### PR DESCRIPTION
Adds test for self addition as a suppressed exception in `AbstractCompletableTask.whenCompleteAsync`.

The problem is in the following code:
```
// exceptions are handled in regular way
failure -> {
    try {
        action.accept(null, failure);
        return forwardException(failure);
    } catch (Throwable e) {
        // CompletableFuture does not override exception here
        // unlike as in handle[Async](BiFunction)
        // Preserve this behavior, but let us add at least 
        // suppressed exception
        failure.addSuppressed(e);
        return forwardException(failure);
    }
}
```
The `forwardException` throws a `CompletionException` which is immediatelly caught by the catch clause. Then, it is added to the `failure` as a suppressed exception. However, it can happen that `failure` == `e` (is the same object) since `failure` is retrown when its type already is the `CompletionException`.